### PR TITLE
float parsing fix

### DIFF
--- a/lib/ru_propisju.rb
+++ b/lib/ru_propisju.rb
@@ -215,7 +215,7 @@ module RuPropisju
   end
   # Выбирает корректный вариант числительного в зависимости от рода и числа и оформляет сумму прописью
   #
-  #   propisju(243) => "двести сорок три"
+  #   propisju(243, 1) => "двести сорок три"
   #   propisju(221, 2) => "двести двадцать одна"
   def propisju(amount, gender, locale = :ru)
     if amount.is_a?(Integer) || amount.is_a?(Bignum)
@@ -417,8 +417,7 @@ module RuPropisju
   }
 
   # Выдает сумму прописью с учетом дробной доли. Дробная доля округляется до миллионной, или (если
-  # дробная доля оканчивается на нули) до ближайшей доли ( 500 тысячных округляется до 5 десятых).
-  # Дополнительный аргумент - род существительного (1 - мужской, 2- женский, 3-средний)
+  # дробная доля оканчивается на нули) до ближайшей доли или точки ( 500 тысячных округляется до 5 десятых, 30.0000 до 30).
   def propisju_float(num, locale = :ru)
     locale_root = pick_locale(DECIMALS, locale)
     source_expression = locale_root[:prefix][0]
@@ -432,8 +431,8 @@ module RuPropisju
     end.freeze
 
     # Укорачиваем до триллионной доли
-    formatted = ("%0.#{words.length}g" % num).gsub(/0+$/, '')
-    wholes, decimals = formatted.split(/\./)
+    formatted = num.to_s[/^\d+(\.\d{0,#{words.length}})?/].gsub(/0+$/, '')
+    wholes, decimals = formatted.split(".")
 
     return propisju_int(wholes.to_i, 1, [], locale) if decimals.to_i.zero?
 

--- a/test/test_ru_propisju.rb
+++ b/test/test_ru_propisju.rb
@@ -99,6 +99,10 @@ class TestRuPropisju < Test::Unit::TestCase
 
   def test_propisju_for_floats
     assert_equal "шесть целых пять десятых", RuPropisju.propisju(6.50, 1)
+    assert_equal "шесть", RuPropisju.propisju(6.0, 1)
+    assert_equal "тридцать миллиардов целых сто одиннадцать тысячных", RuPropisju.propisju(3 * 10**10 + 0.111, 1)
+    assert_equal "тридцать", RuPropisju.propisju(30.0, 1)
+    assert_equal "тридцать целых одна десятая", RuPropisju.propisju(30.1, 1)
     assert_equal "триста сорок одна целая девять десятых", RuPropisju.propisju(341.9, 1)
     assert_equal "триста сорок одна целая двести сорок пять тысячных", RuPropisju.propisju(341.245, 1)
     assert_equal "двести три целых сорок одна сотая", RuPropisju.propisju(203.41, 1)


### PR DESCRIPTION
``` ruby
num = 30.0
("%0.#{13}g" % num).gsub(/0+$/, "")
#=> 3
num = 3 * 10**10
("%0.#{13}g" % num).gsub(/0+$/, "")
#=> 3
num = 3 * 10**12 + 0.1111111
("%0.#{13}g" % num).gsub(/0+$/, "")
#=> 3
num = 3 * 10**11 + 0.1111111
("%0.#{13}g" % num).gsub(/0+$/, "")
#=> 300000000000.1
```
